### PR TITLE
Revert "fixed ccrypto import"

### DIFF
--- a/switchfs/crypto.py
+++ b/switchfs/crypto.py
@@ -5,7 +5,7 @@ if TYPE_CHECKING:
 
 try:
     # noinspection PyProtectedMember
-    from .ccrypto import _xtsn_decrypt, _xtsn_encrypt
+    from ccrypto import _xtsn_decrypt, _xtsn_encrypt
 
 
     class XTSN:


### PR DESCRIPTION
Reverts ihaveamac/switchfs#4

Currently causing relative import issues when trying to run the module directly (e.g. `python3 ./switchfs nand`). I don't really understand why it happens yet. "`ImportError: attempted relative import with no known parent package`"