### PR TITLE
Fix build inconsistency

### DIFF
--- a/switchfs/aes.h
+++ b/switchfs/aes.h
@@ -10,18 +10,9 @@
 // ECB enables the basic ECB 16-byte block algorithm. All can be enabled simultaneously.
 
 // The #ifndef-guard allows it to be configured before #include'ing or at compile time.
-#ifndef CBC
-  #define CBC 1
-#endif
-
-#ifndef ECB
-  #define ECB 1
-#endif
-
-#ifndef CTR
-  #define CTR 1
-#endif
-
+#define CBC 0
+#define ECB 1
+#define CTR 0
 
 #define AES128 1
 //#define AES192 1

--- a/switchfs/ccrypto.c
+++ b/switchfs/ccrypto.c
@@ -6,10 +6,6 @@
 #include <string.h>
 #include <stdbool.h>
 
-#define ECB 1
-#define CBC 0
-#define CTR 0
-
 #include "aes.h"
 
 typedef uint8_t u8;


### PR DESCRIPTION
Because ccrypto.c was built with different flags than aes.c
Generates warnings.